### PR TITLE
change show details to hide details when active

### DIFF
--- a/src/components/workspace/panes/EditorPane.tsx
+++ b/src/components/workspace/panes/EditorPane.tsx
@@ -226,7 +226,7 @@ export default memo(function EditorPane({
             isError={isError}
             onChange={setShowDetails}
           >
-            {strings.showDetails}
+            {showDetails ? strings.hideDetails : strings.showDetails}
           </Button>
         )}
       </Status>

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -34,6 +34,7 @@ const userInterfaceStrings = {
   about: '',
   noErrors: 'No Errors',
   showDetails: 'Show Details',
+  hideDetails: 'Hide Details',
   fullscreen: 'Fullscreen',
   openInNewWindow: 'Open in new window',
   codesandbox: 'Open in CodeSandbox',


### PR DESCRIPTION
Hi, I've noticed the "Show Details" button text doesn't change when it is active. It's not much but I figured I might as well implement a Show/Hide toggling of the text.

PS: Thanks for React Native Express!